### PR TITLE
Compatibility improvements

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -9,10 +9,10 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Middleman Gems
-gem "middleman", "~> 4.0.0"
-gem "middleman-blog"
+gem 'middleman', '~> 4.0.0'
+gem 'middleman-blog'
 
 gem 'redcarpet', '~> 3.3', '>= 3.3.3'
 
 # For feed.xml.builder
-gem "builder", "~> 3.0"
+gem 'builder', '~> 3.0'

--- a/template/config.rb
+++ b/template/config.rb
@@ -5,16 +5,14 @@
 # Per-page layout changes:
 #
 # With no layout
-page '/*.xml', layout: false
-page '/*.json', layout: false
-page '/*.txt', layout: false
+# page '/this-page-has-no-layout.html', layout: false
 
 # With alternative layout
-# page "/path/to/file.html", layout: :otherlayout
+# page '/path/to/file.html', layout: :otherlayout
 
 # Proxy pages (http://middlemanapp.com/basics/dynamic-pages/)
-# proxy "/this-page-has-no-template.html", "/template-file.html", locals: {
-#  which_fake_page: "Rendering a fake page with a local variable" }
+# proxy '/this-page-has-no-template.html', '/template-file.html', locals: {
+#  which_fake_page: 'Rendering a fake page with a local variable' }
 
 ###
 # Helpers
@@ -22,30 +20,29 @@ page '/*.txt', layout: false
 
 activate :blog do |blog|
   # This will add a prefix to all links, template references and source paths
-  # blog.prefix = "blog"
+  # blog.prefix = 'blog'
 
-  # blog.permalink = "{year}/{month}/{day}/{title}.html"
+  # blog.permalink = '{year}/{month}/{day}/{title}.html'
   # Matcher for blog source files
-  # blog.sources = "{year}-{month}-{day}-{title}.html"
-  # blog.taglink = "tags/{tag}.html"
-  # blog.layout = "layout"
+  # blog.sources = '{year}-{month}-{day}-{title}.html'
+  # blog.taglink = 'tags/{tag}.html'
+  # blog.layout = 'layout'
   # blog.summary_separator = /(READMORE)/
   # blog.summary_length = 250
-  # blog.year_link = "{year}.html"
-  # blog.month_link = "{year}/{month}.html"
-  # blog.day_link = "{year}/{month}/{day}.html"
-  # blog.default_extension = ".markdown"
+  # blog.year_link = '{year}.html'
+  # blog.month_link = '{year}/{month}.html'
+  # blog.day_link = '{year}/{month}/{day}.html'
+  # blog.default_extension = '.markdown'
 
-  blog.tag_template = "tag.html"
-  blog.calendar_template = "calendar.html"
+  blog.tag_template = 'tag.html'
+  blog.calendar_template = 'calendar.html'
 
   # Enable pagination
   # blog.paginate = true
   # blog.per_page = 10
-  # blog.page_link = "page/{num}"
+  # blog.page_link = 'page/{num}'
 end
 
-page "/feed.xml", layout: false
 # Reload the browser automatically whenever files change
 # configure :development do
 #   activate :livereload

--- a/template/source/calendar.html.erb
+++ b/template/source/calendar.html.erb
@@ -22,7 +22,7 @@ pageable: true
 
 <ul>
   <% page_articles.each_with_index do |article, i| %>
-    <li><%= link_to article.title, article %> <span><%= article.date.strftime('%b %e') %></span></li>
+    <li><%= link_to article.title, article %> <time datetime="<%= article.date.strftime("%F") %>"<%= article.date.strftime('%b %e') %></time></li>
   <% end %>
 </ul>
 

--- a/template/source/index.html.erb
+++ b/template/source/index.html.erb
@@ -11,7 +11,7 @@ per_page: 10
 <% end %>
 
 <% page_articles.each_with_index do |article, i| %>
-  <h2><%= link_to article.title, article %> <span><%= article.date.strftime('%b %e') %></span></h2>
+  <h2><%= link_to article.title, article %> <time datetime="<%= article.date.strftime("%F") %>"<%= article.date.strftime('%b %e') %></time></h2>
   <!-- use article.summary(250) if you have Nokogiri available to show just
        the first 250 characters -->
   <%= article.body %>

--- a/template/source/layout.erb
+++ b/template/source/layout.erb
@@ -2,9 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv='X-UA-Compatible' content='IE=edge;chrome=1' />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Blog Title<%= ' - ' + current_article.title unless current_article.nil? %></title>
     <%= feed_tag :atom, "#{blog.options.prefix.to_s}/feed.xml", title: "Atom Feed" %>
   </head>

--- a/template/source/layout.erb
+++ b/template/source/layout.erb
@@ -17,7 +17,7 @@
       <h2>Recent Articles</h2>
       <ol>
         <% blog.articles[0...10].each do |article| %>
-          <li><%= link_to article.title, article %> <span><%= article.date.strftime('%b %e') %></span></li>
+          <li><%= link_to article.title, article %> <time datetime="<%= article.date.strftime("%F") %>"<%= article.date.strftime('%b %e') %></time></li>
         <% end %>
       </ol>
 

--- a/template/source/tag.html.erb
+++ b/template/source/tag.html.erb
@@ -14,7 +14,7 @@ per_page: 12
 
 <ul>
   <% page_articles.each_with_index do |article, i| %>
-    <li><%= link_to article.title, article %> <span><%= article.date.strftime('%b %e') %></span></li>
+    <li><%= link_to article.title, article %> <time datetime="<%= article.date.strftime("%F") %>"<%= article.date.strftime('%b %e') %></time></li>
   <% end %>
 </ul>
 


### PR DESCRIPTION
Added trailing slash to viewport meta, removed blank line from the end
and removed the invalid “chrome=1” content for the discontinued Google
Chrome Frame.
