### PR TITLE
[FIX] Add missing gem to gemfile

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Middleman Gems
 gem 'middleman', '~> 4.2'
 gem 'middleman-blog'
+gem 'middleman-autoprefixer', '~> 2.7'
 
 gem 'redcarpet', '~> 3.3', '>= 3.3.3'
 


### PR DESCRIPTION
Out of the box, running `bundle exec middleman server` gets the following error. This PR fixes this.

bundler: failed to load command: middleman (/Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/bin/middleman)
RuntimeError: Unknown Extension: autoprefixer. Check the name and make sure you have referenced the extension's gem in your Gemfile.
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/gems/middleman-core-4.3.6/lib/middleman-core/extensions.rb:86:in `load'
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/gems/middleman-core-4.3.6/lib/middleman-core/extension_manager.rb:51:in `activate'
  /Users/anditto-heristyo/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/forwardable.rb:230:in `activate'
  /Users/anditto-heristyo/ruby_projects/pronihongo_middleman/config.rb:4:in `evaluate_configuration!'
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/gems/middleman-core-4.3.6/lib/middleman-core/application.rb:329:in `instance_eval'
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/gems/middleman-core-4.3.6/lib/middleman-core/application.rb:329:in `evaluate_configuration!'
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/gems/middleman-core-4.3.6/lib/middleman-core/application.rb:286:in `initialize'
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/gems/middleman-cli-4.3.6/bin/middleman:49:in `new'
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/gems/middleman-cli-4.3.6/bin/middleman:49:in `<top (required)>'
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/bin/middleman:23:in `load'
  /Users/anditto-heristyo/.rvm/gems/ruby-2.6.5/bin/middleman:23:in `<top (required)>'